### PR TITLE
Fix scripts in package.json for correct recursive calling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "food-journal",
   "version": "1.0.0",
   "scripts": {
-    "test": "mocha --recursive **/*.test.js",
-    "lint": "eslint **/*.js",
+    "test": "mocha --recursive './{,!(node_modules)/**}/*.test.js'",
+    "lint": "eslint '**/*.js'",
     "fix-style": "eslint --fix **/*.js"
   },
   "devDependencies": {


### PR DESCRIPTION
- Unit test and linting scripts were not recursively running through the file tree
- Tests and linting were only recursing through the first layer of folders

- Fixes implemented fix the recursion issue. Tested on sprint-1 branch. 

Signed-off-by: Arthur Lu <learthurgo@gmail.com>